### PR TITLE
feat(repository): sort links by creation date in findAll method and update tests accordingly

### DIFF
--- a/server/src/repositories/link.repository.spec.ts
+++ b/server/src/repositories/link.repository.spec.ts
@@ -28,7 +28,7 @@ describe('Link Repository', () => {
     })
 
     describe('findAll', () => {
-        it('should return all links in the database', async () => {
+        it('should return all links in the database sorted by creation date', async () => {
             const links = [
                 { originalUrl: 'https://example1.com', shortUrl: 'https://brevly/123' },
                 { originalUrl: 'https://example2.com', shortUrl: 'https://brevly/456' },
@@ -40,8 +40,14 @@ describe('Link Repository', () => {
                 await repository.insert(link.originalUrl, link.shortUrl);
             }
 
+            const firstInsertedLink = links[0];
+            const lastInsertedLink = links[links.length - 1];
+
             const allLinks = await repository.findAll();
+
             expect(allLinks).toHaveLength(links.length);
+            expect(allLinks[0].originalUrl).toBe(lastInsertedLink.originalUrl);
+            expect(allLinks[2].originalUrl).toBe(firstInsertedLink.originalUrl);
         });
 
         it('should return an empty array when no links exist', async () => {

--- a/server/src/repositories/link.repository.ts
+++ b/server/src/repositories/link.repository.ts
@@ -12,7 +12,9 @@ export async function insert(
 }
 
 export async function findAll(): Promise<LinkModel[]> {
-    return db.query.links.findMany();
+    return db.query.links.findMany({
+        orderBy: (links, { desc }) => [desc(links.createdAt)]
+    });
 }
 
 export async function findById(id: string): Promise<LinkModel | undefined> {

--- a/server/src/services/link.service.ts
+++ b/server/src/services/link.service.ts
@@ -29,8 +29,8 @@ export async function create(
 }
 
 export async function list(): Promise<Either<never, LinkModel[]>> {
-    const links = await repository.findAll()
-    return makeRight(links)
+    const links = await repository.findAll();
+    return makeRight(links);
 }
 
 export async function exportLinks(): Promise<Either<AppError, { reportUrl: string }>> {


### PR DESCRIPTION
### Problem

After incrementing a link's count, the application loads all links again. However, the new list is delivered with the last update in the last position, mixing the old order and changing the UI.

Besides make the user confused, while the list grows, it can be hard to rerender.

### Proposal

Return the list always sorted by creation date.

Solves https://github.com/feliperocha93/brevly/issues/25