### PR TITLE
feat: add protection for short URL path and handle forbidden errors

### DIFF
--- a/server/src/routes/link.store.route.ts
+++ b/server/src/routes/link.store.route.ts
@@ -30,6 +30,9 @@ export const store: FastifyPluginAsyncZod = async (app) => {
             message: z.string(),
             issues: z.array(z.any()),
           }),
+          403: z.object({
+            error: z.string(),
+          }),
           409: z.object({
             error: z.string(),
           }),
@@ -53,6 +56,19 @@ export const store: FastifyPluginAsyncZod = async (app) => {
       const error = unwrapEither(result);
 
       switch (error.code) {
+        case AppErrorCode.PROTECTED_PATH:
+          reply.log.warn({
+            request: {
+              method: request.method,
+              url: request.url,
+              body: request.body,
+              query: request.query,
+              params: request.params,
+            }
+          }, generateLogMessage(request, error.code, 403));
+          return reply.status(403).send({
+            error: error.code
+          });
         case AppErrorCode.SHORT_URL_ALREADY_EXISTS:
           reply.log.warn({
             request: {

--- a/server/src/services/link.service.spec.ts
+++ b/server/src/services/link.service.spec.ts
@@ -31,6 +31,19 @@ describe('Link Service', () => {
     })
 
     describe('create', () => {
+        it('should throw an error when path is protected', async () => {
+            vi.mocked(repository.findByShortUrl).mockResolvedValue(mockLink)
+
+            const result = await service.create({
+                originalUrl: 'https://example.com',
+                shortUrlPath: 'url-not-found'
+            })
+
+            expect(result.left).toBeInstanceOf(Error)
+            expect(result.left?.code).toBe(AppErrorCode.PROTECTED_PATH)
+            expect(repository.insert).not.toHaveBeenCalled()
+        })
+
         it('should throw an error when short URL already exists', async () => {
             vi.mocked(repository.findByShortUrl).mockResolvedValue(mockLink)
 
@@ -40,6 +53,7 @@ describe('Link Service', () => {
             })
 
             expect(result.left).toBeInstanceOf(Error)
+            expect(result.left?.code).toBe(AppErrorCode.SHORT_URL_ALREADY_EXISTS)
             expect(repository.insert).not.toHaveBeenCalled()
         })
 
@@ -100,6 +114,7 @@ describe('Link Service', () => {
             const result = await service.incrementAccessCount('mock-uuid')
 
             expect(result.left).toBeInstanceOf(Error)
+            expect(result.left?.code).toBe(AppErrorCode.ID_NOT_FOUND)
             expect(repository.incrementAccessCount).not.toHaveBeenCalled()
         })
 
@@ -121,6 +136,7 @@ describe('Link Service', () => {
             const result = await service.remove('mock-uuid')
 
             expect(result.left).toBeInstanceOf(Error)
+            expect(result.left?.code).toBe(AppErrorCode.ID_NOT_FOUND)
             expect(repository.deleteBy).not.toHaveBeenCalled()
         })
 

--- a/server/src/services/link.service.ts
+++ b/server/src/services/link.service.ts
@@ -13,8 +13,13 @@ export async function create(
     { originalUrl, shortUrlPath }: LinkInsertPayload
 ): Promise<Either<AppError, LinkInsertResponse>> {
     const shortUrl = `${env.APP_DOMAIN}/${shortUrlPath}`
-    const existing = await repository.findByShortUrl(shortUrl)
 
+    const PROTECTED_PATHS = ['url-not-found']
+    if (PROTECTED_PATHS.includes(shortUrlPath)) {
+        return makeLeft(new AppError(AppErrorCode.PROTECTED_PATH))
+    }
+
+    const existing = await repository.findByShortUrl(shortUrl)
     if (existing) {
         return makeLeft(new AppError(AppErrorCode.SHORT_URL_ALREADY_EXISTS))
     }

--- a/server/src/shared/errors.ts
+++ b/server/src/shared/errors.ts
@@ -2,6 +2,7 @@ export const AppErrorCode = {
     ID_NOT_FOUND: 'ID_NOT_FOUND',
     SHORT_URL_ALREADY_EXISTS: 'SHORT_URL_ALREADY_EXISTS',
     NO_LINKS_FOUND: 'NO_LINKS_FOUND',
+    PROTECTED_PATH: 'PROTECTED_PATH',
 } as const;
 
 export type AppErrorCodeType = typeof AppErrorCode[keyof typeof AppErrorCode];

--- a/server/src/tests/integration/link.store.route.spec.ts
+++ b/server/src/tests/integration/link.store.route.spec.ts
@@ -47,6 +47,21 @@ describe('Link routes', () => {
         expect(responseBody).toHaveProperty('error', AppErrorCode.SHORT_URL_ALREADY_EXISTS)
     });
 
+    it('should return a forbidden error when short url is protected', async () => {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/link',
+            payload: {
+                originalUrl: 'https://google.com',
+                shortUrlPath: 'url-not-found'
+            }
+        })
+
+        const responseBody = JSON.parse(response.body)
+        expect(response.statusCode).toBe(403)
+        expect(responseBody).toHaveProperty('error', AppErrorCode.PROTECTED_PATH)
+    });
+
     describe('originalUrl validation', () => {
         it('should return a validation error when originalUrl is not a valid url', async () => {
             const response = await app.inject({


### PR DESCRIPTION
# Description

- Introduced a mechanism to flag certain short URL paths as protected.
- Updated error handling to return a 403 Forbidden error when a protected path is used.
- Added corresponding tests to verify the new behavior across the link service and integration tests.
